### PR TITLE
insufficient UIDs or GIDs available in user namespace 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -27,7 +27,7 @@ RUN mkdir /opt/template2helm && \
 RUN mkdir /opt/odo && \
     cd /opt/odo && \
     curl -L -O https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/odo/latest/odo-linux-amd64.tar.gz && \
-    tar -xf odo-linux-amd64.tar.gz && \
+    tar --no-same-owner -xf odo-linux-amd64.tar.gz && \
     rm odo-linux-amd64.tar.gz
 
 RUN mkdir /opt/argocd && \


### PR DESCRIPTION
odo tarball now seems to be owned by an unusual user, as a result, when trying to untar in the container build, it tried to switch users. Could also be trying to build with podman v3. Error looks like `Error processing tar file(exit status 1): potentially insufficient UIDs or GIDs available in user namespace (requested 103937:103937 for /opt/odo/odo): Check /etc/subuid and /etc/subgid: lchown /opt/odo/odo: invalid argument`. Error is resolved by passing `--no-same-owner` in `tar -x`.